### PR TITLE
Update docker-android-sdk-gradle GRADLE_VERSION to 4.4.1

### DIFF
--- a/docker-android-sdk-gradle/alpine/Dockerfile
+++ b/docker-android-sdk-gradle/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM runmymind/docker-android-sdk:alpine-standalone
 
-ARG GRADLE_VERSION="4.3.1"
+ARG GRADLE_VERSION="4.4.1"
 
 ENV GRADLE_PATH /opt/gradle/gradle-${GRADLE_VERSION}/bin
 ENV PATH $GRADLE_PATH:$PATH

--- a/docker-android-sdk-gradle/ubuntu/Dockerfile
+++ b/docker-android-sdk-gradle/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM runmymind/docker-android-sdk:ubuntu-standalone
 
-ARG GRADLE_VERSION="4.3.1"
+ARG GRADLE_VERSION="4.4.1"
 
 ENV GRADLE_PATH /opt/gradle/gradle-${GRADLE_VERSION}/bin
 ENV PATH $GRADLE_PATH:$PATH


### PR DESCRIPTION
I have a project that is using gradle version 4.4.1. Building with this image gives us the error:

```
   > Minimum supported Gradle version is 4.4. Current version is 4.3.1. If using the gradle wrapper, try editing the distributionUrl in /app/gradle/wrapper/gradle-wrapper.properties to gradle-4.4-all.zip
```

I'm unsure if this can be fixed on our side (editing the distributionUrl as stated?), but I do think it can be fixed container-side. I'm not sure if this will have any breaking changes.

Alternatively, it would be nice to have some kind of tag matrix or similar, but not sure if that's hard to setup (khoanguyent/docker-android-sdk-gradle:alpine-4.4.1, etc)

:heart: 